### PR TITLE
Add support for 64-bit kernels

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -24,8 +24,10 @@ import errno
 # used by archive file and unpacked archive
 DISK_USAGE_MB = 900
 
-PROCESSOR_TYPES = range(0, 4)
-PROCESSOR_TYPES_NAMES = ['BCM2835', 'BCM2836', 'BCM2837', 'BCM2711']
+PROCESSOR_TYPES_NAMES = ('BCM2835', 'BCM2836', 'BCM2837', 'BCM2711')
+PROCESSOR_TYPES = range(0, len(PROCESSOR_TYPES_NAMES))
+ARCHITECTURE_TYPES_NAMES = ('32-bit', '64-bit')
+ARCHITECTURE_TYPES = range(0, len(ARCHITECTURE_TYPES_NAMES))
 
 help = "https://github.com/RPi-Distro/rpi-source/blob/master/README.md"
 script_repo = "https://github.com/RPi-Distro/rpi-source"
@@ -56,6 +58,7 @@ parser.add_argument("-q", "--quiet", help="Quiet",
 parser.add_argument("-g", "--default-config", help="Generate a default kernel configuration with 'make bcmrpi_defconfig'",
                     action="store_true")
 parser.add_argument("--processor", type=int, choices=PROCESSOR_TYPES, help="Override Processor type")
+parser.add_argument("--architecture", type=int, choices=ARCHITECTURE_TYPES, help="Override Architecture type")
 parser.add_argument("--skip-gcc", help=argparse.SUPPRESS, action="store_true")  # Deprecated
 parser.add_argument("--skip-space", help="Skip disk space check",
                     action="store_true")
@@ -213,16 +216,30 @@ def proc_config_gz():
         return f.read()
 
 
-def processor_type_suffix():
-    if processor_type == 0:
-        return ''
-    elif processor_type == 1 or processor_type == 2:
-        return '7'
-    elif processor_type == 3:
-        return '7l'
-    else:
+def kernel_suffix():
+    if processor_type not in PROCESSOR_TYPES:
         fail("Unsupported processor_type %d" % processor_type)
+    if architecture_type not in ARCHITECTURE_TYPES:
+        fail("Unsupported architecture_type %d" % architecture_type)
 
+    if processor_type == 0: # BCM2835 uses kernel.img
+        if architecture_type == 0:
+            return ''
+    elif processor_type == 1: # BCM2836 uses kernel7.img
+        if architecture_type == 0:
+            return '7'
+    elif processor_type == 2: # BCM2837 uses kernel7.img or kernel8.img
+        if architecture_type == 0:
+            return '7'
+        elif architecture_type == 1:
+            return '8'
+    elif processor_type == 3: # BCM2711 uses kernel7l.img or kernel8.img
+        if architecture_type == 0:
+            return '7l'
+        elif architecture_type == 1:
+            return '8'
+
+    fail("Unsupported combination of processor_type %d and architecture_type %d" % (processor_type, architecture_type))
 
 def rpi_update_method(uri):
     kernel = Kernel()
@@ -239,7 +256,7 @@ def rpi_update_method(uri):
     repo_raw = "https://raw.githubusercontent.com%s" % repo_short
 
     kernel.git_hash = download("%s/%s/git_hash" % (repo_raw, fw_rev)).strip()
-    kernel.symvers = "%s/%s/Module%s.symvers" % (repo_raw, fw_rev, processor_type_suffix())
+    kernel.symvers = "%s/%s/Module%s.symvers" % (repo_raw, fw_rev, kernel_suffix())
 
     if not args.default_config:
         kernel.config = proc_config_gz()
@@ -264,7 +281,7 @@ def debian_method(fn):
     repo_raw = "https://raw.githubusercontent.com/raspberrypi/firmware"
 
     kernel.git_hash = download("%s/%s/extra/git_hash" % (repo_raw, fw_rev)).strip()
-    kernel.symvers = "%s/%s/extra/Module%s.symvers" % (repo_raw, fw_rev, processor_type_suffix())
+    kernel.symvers = "%s/%s/extra/Module%s.symvers" % (repo_raw, fw_rev, kernel_suffix())
 
     if not args.default_config:
         kernel.config = proc_config_gz()
@@ -315,6 +332,15 @@ def get_processor_type():
     return processor
 
 
+def get_architecture_type():
+    if args.architecture is not None:
+        return args.architecture
+
+    if platform.machine() == 'aarch64':
+        return 1
+    else:
+        return 0
+
 def check_bc():
     if not os.path.exists('/usr/bin/bc'):
         fail("bc is NOT installed. Needed by 'make modules_prepare'. On Raspberry Pi OS,\nrun 'sudo apt install bc' to install it.")
@@ -323,6 +349,9 @@ def check_bc():
 
 processor_type = get_processor_type()
 info("SoC: %s" % PROCESSOR_TYPES_NAMES[processor_type])
+
+architecture_type = get_architecture_type()
+info("Arch: %s" % ARCHITECTURE_TYPES_NAMES[architecture_type])
 
 # FIX usage of -d DEST with relative pathnames
 args.dest = os.path.abspath(args.dest)
@@ -393,8 +422,13 @@ if args.default_config or not kernel.config:
     info(".config (generating default)")
     if processor_type == 0:
         sh("cd %s && make bcmrpi_defconfig" % (linux_symlink,))
-    elif processor_type == 1 or processor_type == 2:
+    elif processor_type == 1:
         sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
+    elif processor_type == 2:
+        if architecture_type == 0:
+            sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
+        elif architecture_type == 1:
+            sh("cd %s && make bcmrpi3_defconfig" % (linux_symlink,))
     elif processor_type == 3:
         sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
     else:


### PR DESCRIPTION
I _think_ this is right, but I can't be 100% sure.
I've tested the execution of the script itself on 32-bit Raspberry Pi OS running on a Pi400 and on 64-bit Raspberry Pi OS running on a Pi4B, but haven't checked any other Pis. And I've also not tried building any actual out-of-tree kernel modules.

But it _should_ fix the issues with `rpi-source` identified in https://github.com/raspberrypi/Raspberry-Pi-OS-64bit/issues/4#issuecomment-717538559