### PR TITLE
download-only option

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -63,6 +63,8 @@ parser.add_argument("--skip-update", help="Skip checking for update to this scri
                     action="store_true")
 parser.add_argument("--tag-update", help="Tell the update mechanism that this is the latest version of the script",
                     action="store_true")
+parser.add_argument("--download-only", help="Just download the kernel tarball, without unpacking source and installing it",
+                    action="store_true",)
 args = parser.parse_args()
 
 
@@ -366,6 +368,10 @@ if not os.path.exists(linux_tar):
     sh("wget %s -O %s https://github.com/raspberrypi/linux/archive/%s.tar.gz" % (("-q" if args.quiet else ""), linux_tar, kernel.git_hash))
 else:
     info("Download kernel source: Already downloaded %s" % linux_tar)
+
+if args.download_only:
+    info("Downloaded kernel source tarball: %s" % linux_tar)
+    quit()
 
 info("Unpack kernel source")
 if args.quiet:


### PR DESCRIPTION
__*download-only* option__

Added *--download-only* option, to just download the kernel source tarball, without unpacking and installing it.
Sometimes it is not required to have the whole kernel unpacked, but just a single directory, that can be easily extracted from the tarball, like in the following example:

```bash
kdir=$(rpi-source -s|grep commit|awk 'NF>1{print $NF}')
tar xvf /root/linux-$kdir.tar.gz linux-$kdir/path-to-extract
```

[edit: revised code to only keep *download-only* option]