### PR TITLE
Improved error message

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -109,7 +109,10 @@ def download(url):
     try:
         res = urllib2.urlopen(url).read()
     except urllib2.HTTPError, e:
-        fail("Couldn't download %s, HTTPError: %s" % (url, e.code))
+        fail(
+            "Couldn't download %s, HTTPError: %s\n\n%s"
+            % (url, e.code, json.dumps(json.load(e), indent=4))
+        )
     except urllib2.URLError, e:
         fail("Couldn't download %s, URLError: %s" % (url, e.args))
     return res


### PR DESCRIPTION
__Improved error message__

Now the error message from *github api* also shows details, like in the following example (which might occur sometimes):

```json
*** SoC: BCM2711
ERROR:
Couldn't download https://api.github.com/repos/RPi-Distro/rpi-source/git/refs/heads/master, HTTPError: 403

{
   "documentation_url": "https://developer.github.com/v3/#rate-limiting",
   "message": "API rate limit exceeded for 80.116.12.179. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"
}

Help: https://github.com/RPi-Distro/rpi-source/blob/master/README.md
```