### PR TITLE
Bugfix in rpi-source

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -110,12 +110,12 @@ def download(url):
     debug("download: %s" % url)
     try:
         res = urllib2.urlopen(url).read()
-    except urllib2.HTTPError, e:
+    except urllib2.HTTPError as e:
         fail(
             "Couldn't download %s, HTTPError: %s\n\n%s"
             % (url, e.code, json.dumps(json.load(e), indent=4))
         )
-    except urllib2.URLError, e:
+    except urllib2.URLError as e:
         fail("Couldn't download %s, URLError: %s" % (url, e.args))
     return res
 


### PR DESCRIPTION
```
  File "/usr/local/bin/rpi-source", line 113
    except urllib2.HTTPError, e:
                            ^
SyntaxError: invalid syntax
```