### PR TITLE
Update rpi-source to specify python2

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Copyright (C) 2014 Noralf Tronnes


### PR DESCRIPTION
Helpful for those who don't use python2 as their default