### PR TITLE
Python2 is not included anymore but needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The script uses sudo internally when self-updating and when making the links */l
 
 Dependencies
 ```text
-sudo apt install git bc bison flex libssl-dev
+sudo apt install git bc bison flex libssl-dev python2
 ```
 
 Install


### PR DESCRIPTION
Either one fixes this script for a current python version, or installs python 2. Either way, the current version of it needs python2, so one should install it.