### PR TITLE
Add support for 64-bit kernels

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -444,7 +444,7 @@ if args.default_config or not kernel.config:
         if architecture_type == 0:
             sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
         elif architecture_type == 1:
-            sh("cd %s && make bcmrpi3_defconfig" % (linux_symlink,))
+            sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
     elif processor_type == 3:
         sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
     else:

--- a/rpi-source
+++ b/rpi-source
@@ -24,8 +24,10 @@ import errno
 # used by archive file and unpacked archive
 DISK_USAGE_MB = 900
 
-PROCESSOR_TYPES = list(range(0, 4))
-PROCESSOR_TYPES_NAMES = ['BCM2835', 'BCM2836', 'BCM2837', 'BCM2711']
+PROCESSOR_TYPES_NAMES = ('BCM2835', 'BCM2836', 'BCM2837', 'BCM2711')
+PROCESSOR_TYPES = range(0, len(PROCESSOR_TYPES_NAMES))
+ARCHITECTURE_TYPES_NAMES = ('32-bit', '64-bit')
+ARCHITECTURE_TYPES = range(0, len(ARCHITECTURE_TYPES_NAMES))
 
 help = "https://github.com/RPi-Distro/rpi-source/blob/master/README.md"
 script_repo = "https://github.com/RPi-Distro/rpi-source"
@@ -56,6 +58,7 @@ parser.add_argument("-q", "--quiet", help="Quiet",
 parser.add_argument("-g", "--default-config", help="Generate a default kernel configuration with 'make bcmrpi_defconfig'",
                     action="store_true")
 parser.add_argument("--processor", type=int, choices=PROCESSOR_TYPES, help="Override Processor type")
+parser.add_argument("--architecture", type=int, choices=ARCHITECTURE_TYPES, help="Override Architecture type")
 parser.add_argument("--skip-gcc", help=argparse.SUPPRESS, action="store_true")  # Deprecated
 parser.add_argument("--skip-space", help="Skip disk space check",
                     action="store_true")
@@ -217,17 +220,31 @@ def proc_config_gz():
     with gzip.open('/proc/config.gz', 'rb') as f:
         return f.read().decode('utf-8')
 
-
-def processor_type_suffix():
-    if processor_type == 0:
-        return ''
-    elif processor_type == 1 or processor_type == 2:
-        return '7'
-    elif processor_type == 3:
-        return '7l'
-    else:
+def kernel_suffix():
+    if processor_type not in PROCESSOR_TYPES:
         fail("Unsupported processor_type %d" % processor_type)
 
+    if architecture_type not in ARCHITECTURE_TYPES:
+        fail("Unsupported architecture_type %d" % architecture_type)
+
+    if processor_type == 0: # BCM2835 uses kernel.img
+        if architecture_type == 0:
+            return ''
+    elif processor_type == 1: # BCM2836 uses kernel7.img
+        if architecture_type == 0:
+            return '7'
+    elif processor_type == 2: # BCM2837 uses kernel7.img or kernel8.img
+        if architecture_type == 0:
+            return '7'
+        elif architecture_type == 1:
+            return '8'
+    elif processor_type == 3: # BCM2711 uses kernel7l.img or kernel8.img
+        if architecture_type == 0:
+            return '7l'
+        elif architecture_type == 1:
+            return '8'
+
+    fail("Unsupported combination of processor_type %d and architecture_type %d" % (processor_type, architecture_type))
 
 def rpi_update_method(uri):
     kernel = Kernel()
@@ -244,7 +261,7 @@ def rpi_update_method(uri):
     repo_raw = "https://raw.githubusercontent.com%s" % repo_short
 
     kernel.git_hash = download("%s/%s/git_hash" % (repo_raw, fw_rev)).strip()
-    kernel.symvers = "%s/%s/Module%s.symvers" % (repo_raw, fw_rev, processor_type_suffix())
+    kernel.symvers = "%s/%s/Module%s.symvers" % (repo_raw, fw_rev, kernel_suffix())
 
     if not args.default_config:
         kernel.config = proc_config_gz()
@@ -269,7 +286,7 @@ def debian_method(fn):
     repo_raw = "https://raw.githubusercontent.com/raspberrypi/firmware"
 
     kernel.git_hash = download("%s/%s/extra/git_hash" % (repo_raw, fw_rev)).strip()
-    kernel.symvers = "%s/%s/extra/Module%s.symvers" % (repo_raw, fw_rev, processor_type_suffix())
+    kernel.symvers = "%s/%s/extra/Module%s.symvers" % (repo_raw, fw_rev, kernel_suffix())
 
     if not args.default_config:
         kernel.config = proc_config_gz()
@@ -320,6 +337,16 @@ def get_processor_type():
     return processor
 
 
+def get_architecture_type():
+    if args.architecture is not None:
+        return args.architecture
+
+    if platform.machine() == 'aarch64':
+        return 1
+    else:
+        return 0
+
+
 def check_bc():
     if not os.path.exists('/usr/bin/bc'):
         fail("bc is NOT installed. Needed by 'make modules_prepare'. On Raspberry Pi OS,\nrun 'sudo apt install bc' to install it.")
@@ -328,6 +355,9 @@ def check_bc():
 
 processor_type = get_processor_type()
 info("SoC: %s" % PROCESSOR_TYPES_NAMES[processor_type])
+
+architecture_type = get_architecture_type()
+info("Arch: %s" % ARCHITECTURE_TYPES_NAMES[architecture_type])
 
 # FIX usage of -d DEST with relative pathnames
 args.dest = os.path.abspath(args.dest)
@@ -408,8 +438,13 @@ if args.default_config or not kernel.config:
     info(".config (generating default)")
     if processor_type == 0:
         sh("cd %s && make bcmrpi_defconfig" % (linux_symlink,))
-    elif processor_type == 1 or processor_type == 2:
+    elif processor_type == 1:
         sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
+    elif processor_type == 2:
+        if architecture_type == 0:
+            sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
+        elif architecture_type == 1:
+            sh("cd %s && make bcmrpi3_defconfig" % (linux_symlink,))
     elif processor_type == 3:
         sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
     else:

--- a/rpi-source
+++ b/rpi-source
@@ -24,7 +24,7 @@ import errno
 # used by archive file and unpacked archive
 DISK_USAGE_MB = 900
 
-PROCESSOR_TYPES_NAMES = ('BCM2835', 'BCM2836', 'BCM2837', 'BCM2711')
+PROCESSOR_TYPES_NAMES = ('BCM2835', 'BCM2836', 'BCM2837', 'BCM2711', 'BCM2712')
 PROCESSOR_TYPES = range(0, len(PROCESSOR_TYPES_NAMES))
 ARCHITECTURE_TYPES_NAMES = ('32-bit', '64-bit')
 ARCHITECTURE_TYPES = range(0, len(ARCHITECTURE_TYPES_NAMES))
@@ -243,6 +243,11 @@ def kernel_suffix():
             return '7l'
         elif architecture_type == 1:
             return '8'
+    elif processor_type == 4: # BCM2712 uses kernel8.img or kernel_2712.img
+        if architecture_type == 1 and page_size == 4096:
+            return '8'
+        if architecture_type == 1 and page_size == 16384:
+            return '_2712'
 
     fail("Unsupported combination of processor_type %d and architecture_type %d" % (processor_type, architecture_type))
 
@@ -347,6 +352,13 @@ def get_architecture_type():
         return 0
 
 
+def get_page_size():
+    page_size = int(sh_out("getconf PAGESIZE"))
+    if (page_size % 4096) != 0:
+        fail("Unexpected page size: %d, exiting" % (page_size))
+    return page_size
+
+
 def check_bc():
     if not os.path.exists('/usr/bin/bc'):
         fail("bc is NOT installed. Needed by 'make modules_prepare'. On Raspberry Pi OS,\nrun 'sudo apt install bc' to install it.")
@@ -358,6 +370,9 @@ info("SoC: %s" % PROCESSOR_TYPES_NAMES[processor_type])
 
 architecture_type = get_architecture_type()
 info("Arch: %s" % ARCHITECTURE_TYPES_NAMES[architecture_type])
+
+page_size = get_page_size()
+info("Page Size: %d" % page_size)
 
 # FIX usage of -d DEST with relative pathnames
 args.dest = os.path.abspath(args.dest)
@@ -447,6 +462,11 @@ if args.default_config or not kernel.config:
             sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
     elif processor_type == 3:
         sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
+    elif processor_type == 4:
+        if page_size == 4096:
+            sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
+        elif page_size == 16384:
+            sh("cd %s && make bcm2712_defconfig" % (linux_symlink,))
     else:
         fail("Unsupported processor_type %d" % processor_type)
 else:

--- a/rpi-source
+++ b/rpi-source
@@ -451,24 +451,27 @@ sh("sudo ln -sf %s /lib/modules/$(uname -r)/source" % linux_symlink)
 
 if args.default_config or not kernel.config:
     info(".config (generating default)")
+    defconfig = None
     if processor_type == 0:
-        sh("cd %s && make bcmrpi_defconfig" % (linux_symlink,))
+        defconfig = "bcmrpi_defconfig"
     elif processor_type == 1:
-        sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
+        defconfig = "bcm2709_defconfig"
     elif processor_type == 2:
         if architecture_type == 0:
-            sh("cd %s && make bcm2709_defconfig" % (linux_symlink,))
+            defconfig = "bcm2709_defconfig"
         elif architecture_type == 1:
-            sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
+            defconfig = "bcm2711_defconfig"
     elif processor_type == 3:
-        sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
+        defconfig = "bcm2711_defconfig"
     elif processor_type == 4:
         if page_size == 4096:
-            sh("cd %s && make bcm2711_defconfig" % (linux_symlink,))
+            defconfig = "bcm2711_defconfig"
         elif page_size == 16384:
-            sh("cd %s && make bcm2712_defconfig" % (linux_symlink,))
+            defconfig = "bcm2712_defconfig"
+    if defconfig is not None:
+        sh("cd %s && make %s" % (linux_symlink, defconfig))
     else:
-        fail("Unsupported processor_type %d" % processor_type)
+        fail("Unsupported processor_type: %d, architecture_type: %d" % (processor_type, architecture_type))
 else:
     info(".config")
     writef(os.path.join(linux_dir, '.config'), kernel.config)


### PR DESCRIPTION
This is a verbatim rebase of the changes provided by @lurch to resolve #2. Thank you @lurch. This also will resolve issue #22 posted by @Zahrun. Tested on 64-bit Raspberry Pi OS running on a Pi4B, building kernel modules for the zfs-dkms and zfsutils-linux packages on bullseye with kernel 6.1.73-v8+.

It should fix the issues with `rpi-source` identified in https://github.com/raspberrypi/Raspberry-Pi-OS-64bit/issues/4#issuecomment-717538559