### PR TITLE
fix: point to python3 in shebang

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright (C) 2014 Noralf Tronnes


### PR DESCRIPTION
The goal of this PR is to explicitly call python3 from shebang by default.

Just stepped into the issue on older buster installation after upgrading kernel with `rpi-update` and trying to use `rpi-source` to get matching sources: there were both python2 and python3 installed, with the default (`/usr/bin/python`) pointing to python2.

This is a follow-up after https://github.com/RPi-Distro/rpi-source/pull/17/commits/143de0765dec0cb404d96386df3ffc1533dc303b (https://github.com/RPi-Distro/rpi-source/pull/17).

Fixes https://github.com/RPi-Distro/rpi-source/issues/26.